### PR TITLE
Fedora: Add directories config option

### DIFF
--- a/lib/pkgr/cli.rb
+++ b/lib/pkgr/cli.rb
@@ -134,6 +134,9 @@ module Pkgr
       :type => :string,
       :default => default_data_dir,
       :desc => "Path to data directory. Can be used for overriding default templates, hooks(pre-, post- scripts), configs (buildpacks, distro dependencies), environments, etc. To retrieve default files you can use data command"
+    method_option :directories,
+      :type => :string,
+      :desc => "Recursively mark a directory as being owned by the package. This option is just passed to fpm."
 
     def package(tarball)
       Pkgr.level = Logger::INFO if options[:verbose]

--- a/lib/pkgr/config.rb
+++ b/lib/pkgr/config.rb
@@ -116,6 +116,10 @@ module Pkgr
       @table[:data_dir] || Pkgr::CLI.default_data_dir
     end
 
+    def directories
+      @table[:directories] || nil
+    end
+
     def valid?
       @errors = []
       @errors.push("name can't be blank") if name.nil? || name.empty?

--- a/lib/pkgr/distributions/fedora.rb
+++ b/lib/pkgr/distributions/fedora.rb
@@ -58,6 +58,7 @@ module Pkgr
           args << %{--after-install "#{postinstall_file}"}
           args << %{--before-remove "#{preuninstall_file}"}
           args << %{--after-remove "#{postuninstall_file}"}
+          args << %{--directories "#{config.directories}"} if config.directories
           args << dependencies(config.dependencies).map{|d| "-d '#{d}'"}.join(" ")
           args << "."
         end


### PR DESCRIPTION
This option is used to specify directories which will be ownd by the package and
will be removed with when the package will be erased.